### PR TITLE
add pokemon info details

### DIFF
--- a/pokedex/src/components/PokemonInfo/PokemonInfo.js
+++ b/pokedex/src/components/PokemonInfo/PokemonInfo.js
@@ -12,6 +12,7 @@ import EditPokemonInfoModal from "./EditPokemonInfoModal";
 import DelPokemonInfoModal from "./DelPokemonInfoModal";
 import Pages from "../Page";
 import { ListGroup } from 'react-bootstrap';
+import PokemonInfoDetailsModal from './PokemonInfoDetails';
 
 // The main tab for rendering pokemon information
 export function PokemonInfoTab(props) {
@@ -32,7 +33,8 @@ class PokemonInfoList extends React.Component {
             pokemonInfoIndex: -1,
             addModalVisible: false,
             editModalVisible: false,
-            delModalVisible: false
+            delModalVisible: false,
+            detailModalVisible: false
         }
     }
 
@@ -78,6 +80,12 @@ class PokemonInfoList extends React.Component {
                         <Button className="me-2" onClick={() => {
                             this.setState({
                                 pokemonInfoIndex: pokeInfo.pk,
+                                detailModalVisible: true
+                            })
+                        }}>Details</Button>
+                        <Button className="me-2" onClick={() => {
+                            this.setState({
+                                pokemonInfoIndex: pokeInfo.pk,
                                 editModalVisible: true
                             })
                         }}>Edit</Button>
@@ -106,6 +114,11 @@ class PokemonInfoList extends React.Component {
             handleClose={() => this.setState({delModalVisible: false})}
             handleDel={(payload) => this.handleDel(payload)}
             national_num={this.state.pokemonInfo[this.findIndex(this.state.pokemonInfoIndex)]?.pk} />
+        <PokemonInfoDetailsModal
+            show={this.state.detailModalVisible}
+            handleClose={() => this.setState({detailModalVisible: false})}
+            pokemonInfo={this.state.pokemonInfo}
+            pokemonInfoIndex={this.findIndex(this.state.pokemonInfoIndex)} />
     </div>
     }
 }

--- a/pokedex/src/components/PokemonInfo/PokemonInfoDetails.js
+++ b/pokedex/src/components/PokemonInfo/PokemonInfoDetails.js
@@ -24,11 +24,15 @@ export default function PokemonInfoDetailsModal({ show, handleClose, pokemonInfo
             if (devolvedStateID !== null) {
                 let devolvedPokemon = pokemonInfo.find(info => info.pk === devolvedStateID)
                 setDevolvedState(`${devolvedStateID} ${devolvedPokemon.fields.name}`)
+            } else {
+                setDevolvedState("")
             }
             let evolvedStateID = currInfoFields.evolved_state_pkid
             if (evolvedStateID !== null) {
                 let evolvedPokemon = pokemonInfo.find(info => info.pk === evolvedStateID)
                 setEvolvedState(`${evolvedStateID} ${evolvedPokemon.fields.name}`)
+            } else {
+                setEvolvedState("")
             }
 
             setNationalNumber(currInfo.pk)

--- a/pokedex/src/components/PokemonInfo/PokemonInfoDetails.js
+++ b/pokedex/src/components/PokemonInfo/PokemonInfoDetails.js
@@ -1,0 +1,63 @@
+// A component for rendering the details of a Pokemon Info, displaying all fields
+// in the pokemon info instead of a subset.
+
+import React from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+import { Image } from 'react-bootstrap';
+const { useState, useEffect } = React;
+
+export default function PokemonInfoDetailsModal({ show, handleClose, pokemonInfo, pokemonInfoIndex }) {
+    const [nationalNumber, setNationalNumber] = useState("")
+    const [name, setName] = useState("")
+    const [photoUrl, setPhotoUrl] = useState("")
+    const [description, setDescription] = useState("")
+    const [devolvedState, setDevolvedState] = useState("")
+    const [evolvedState, setEvolvedState] = useState("")
+
+    useEffect(() => {
+        if (pokemonInfo.length !== 0) {
+            let currInfo = pokemonInfo[pokemonInfoIndex]
+            let currInfoFields = currInfo.fields
+
+            let devolvedStateID = currInfoFields.devolved_state_pkid
+            if (devolvedStateID !== null) {
+                let devolvedPokemon = pokemonInfo.find(info => info.pk === devolvedStateID)
+                setDevolvedState(`${devolvedStateID} ${devolvedPokemon.fields.name}`)
+            }
+            let evolvedStateID = currInfoFields.evolved_state_pkid
+            if (evolvedStateID !== null) {
+                let evolvedPokemon = pokemonInfo.find(info => info.pk === evolvedStateID)
+                setEvolvedState(`${evolvedStateID} ${evolvedPokemon.fields.name}`)
+            }
+
+            setNationalNumber(currInfo.pk)
+            setName(currInfoFields.name)
+            setPhotoUrl(currInfoFields.photo_url)
+            setDescription(currInfoFields.description)
+        }
+    }, [pokemonInfoIndex])
+    return <>
+        <Modal show={show} onHide={handleClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>{name}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                National Number: <b>{nationalNumber}</b>
+                <br />
+                Name: <b>{name}</b>
+                <br />
+                Description: <i>{description}</i>
+                <br />
+                {(devolvedState.length === 0) ? null : <><p>Devolved State: {devolvedState}</p><br /></>}
+                {(evolvedState.length === 0) ? null : <><p>Evolved State: {evolvedState}</p><br /></>}
+                Photo: <Image src={photoUrl} fluid />
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" onClick={handleClose}>
+                    Close
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    </>
+}


### PR DESCRIPTION
Adds Pokemon Info details page to each of the pokemoninfo entries in the list screen.

![image](https://user-images.githubusercontent.com/24576987/145720465-d7d76ca5-a4f7-4996-97ad-630ed91ac741.png)

![image](https://user-images.githubusercontent.com/24576987/145720306-21351d16-c560-45bb-acfa-b5cdf3ea829d.png)

![image](https://user-images.githubusercontent.com/24576987/145720339-d5d4f185-fbeb-4840-9fd4-655d5f95fad6.png)

Closes #19 