### PR TITLE
add initial pokedex listing + upgrade to React Router v6

### DIFF
--- a/pokedex/package-lock.json
+++ b/pokedex/package-lock.json
@@ -16,7 +16,7 @@
         "react-bootstrap": "^2.0.2",
         "react-dom": "^17.0.2",
         "react-markdown": "^7.1.1",
-        "react-router-dom": "^5.3.0",
+        "react-router-dom": "^6.1.1",
         "react-scripts": "4.0.3",
         "url-join": "^4.0.1",
         "web-vitals": "^1.0.1"
@@ -8889,16 +8889,11 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/hmac-drbg": {
@@ -8910,19 +8905,6 @@
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
       }
-    },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
-    "node_modules/hoist-non-react-statics/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/hoopy": {
       "version": "0.1.4",
@@ -12207,19 +12189,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      },
-      "peerDependencies": {
-        "prop-types": "^15.0.0",
-        "react": "^0.14.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/mini-css-extract-plugin": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
@@ -15423,59 +15392,28 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
-      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.1.1.tgz",
+      "integrity": "sha512-55o96RiDZmC0uD17DPqVmzzfdNd2Dc+EjkYvMAmHl43du/GItaTdFr5WwjTryNWPXZ+OOVQxQhwAX25UwxpHtw==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.1.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
-      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.1.1.tgz",
+      "integrity": "sha512-O3UH89DI4o+swd2q6lF4dSmpuNCxwkUXcj0zAFcVc1H+YoPE6T7uwoFMX0ws1pUvCY8lYDucFpOqCCdal6VFzg==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.1",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.1.0",
+        "react-router": "6.1.1"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
-    "node_modules/react-router/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-scripts": {
       "version": "4.0.3",
@@ -16080,11 +16018,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve-url": {
       "version": "0.2.1",
@@ -18482,16 +18415,6 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -19295,11 +19218,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -28264,16 +28182,11 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.1.0.tgz",
+      "integrity": "sha512-zPuQgPacm2vH2xdORvGGz1wQMuHSIB56yNAy5FnLuwOwgSYyPKptJtcMm6Ev+hRGeS+GzhbmRacHzvlESbFwDg==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "hmac-drbg": {
@@ -28284,21 +28197,6 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "requires": {
-        "react-is": "^16.7.0"
-      },
-      "dependencies": {
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
       }
     },
     "hoopy": {
@@ -30732,15 +30630,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
-    },
-    "mini-create-react-context": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
-      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
-      "requires": {
-        "@babel/runtime": "^7.12.1",
-        "tiny-warning": "^1.0.3"
-      }
     },
     "mini-css-extract-plugin": {
       "version": "0.11.3",
@@ -33307,54 +33196,20 @@
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
     "react-router": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
-      "integrity": "sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.1.1.tgz",
+      "integrity": "sha512-55o96RiDZmC0uD17DPqVmzzfdNd2Dc+EjkYvMAmHl43du/GItaTdFr5WwjTryNWPXZ+OOVQxQhwAX25UwxpHtw==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.4.0",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        },
-        "path-to-regexp": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-          "requires": {
-            "isarray": "0.0.1"
-          }
-        },
-        "react-is": {
-          "version": "16.13.1",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-        }
+        "history": "^5.1.0"
       }
     },
     "react-router-dom": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.0.tgz",
-      "integrity": "sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.1.1.tgz",
+      "integrity": "sha512-O3UH89DI4o+swd2q6lF4dSmpuNCxwkUXcj0zAFcVc1H+YoPE6T7uwoFMX0ws1pUvCY8lYDucFpOqCCdal6VFzg==",
       "requires": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.2.1",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "history": "^5.1.0",
+        "react-router": "6.1.1"
       }
     },
     "react-scripts": {
@@ -33817,11 +33672,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
-    },
-    "resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -35738,16 +35588,6 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
-    "tiny-invariant": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
-      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
-    },
-    "tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -36346,11 +36186,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/pokedex/package.json
+++ b/pokedex/package.json
@@ -11,7 +11,7 @@
     "react-bootstrap": "^2.0.2",
     "react-dom": "^17.0.2",
     "react-markdown": "^7.1.1",
-    "react-router-dom": "^5.3.0",
+    "react-router-dom": "^6.1.1",
     "react-scripts": "4.0.3",
     "url-join": "^4.0.1",
     "web-vitals": "^1.0.1"

--- a/pokedex/src/App.js
+++ b/pokedex/src/App.js
@@ -4,7 +4,7 @@ import { Container, Nav, Navbar } from 'react-bootstrap';
 import logo from './pokeball.png'
 import {
   BrowserRouter as Router,
-  Switch,
+  Routes,
   Route,
   Link
 } from "react-router-dom";
@@ -33,10 +33,18 @@ function App() {
               </Navbar.Brand>
               <Navbar.Collapse id="basic-navbar-nav">
                 <Nav className="me-auto">
-                  <Link to="/" component={Nav.Link}>Home</Link>
-                  <Link to="/pokemonInfo" component={Nav.Link}>Pokemon Info</Link>
-                  <Link to="/trainers" component={Nav.Link}>Trainers</Link>
-                  <Link to="/moves" component={Nav.Link}>Pokemon Moves</Link>
+                  <Nav.Item>
+                    <Nav.Link href="/">Home</Nav.Link>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <Nav.Link href="/pokemonInfo">Pokemon Info</Nav.Link>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <Nav.Link href="/trainers">Trainers</Nav.Link>
+                  </Nav.Item>
+                  <Nav.Item>
+                    <Nav.Link href="/moves">Moves</Nav.Link>
+                  </Nav.Item>
                 </Nav>
               </Navbar.Collapse>
             </Container>
@@ -44,20 +52,13 @@ function App() {
 
           {/* A <Switch> looks through its children <Route>s and
             renders the first one that matches the current URL. */}
-          <Switch>
-            <Route path="/" exact>
-              <Home />
+          <Routes>
+            <Route path="/" exact element={<Home />} />
+            <Route path="/pokemonInfo" exact element={<PokemonInfoTab />} />
+            <Route path="/trainers/*" element={<Trainers />} />
+            <Route path="/moves" exact element={<Moves />}>
             </Route>
-            <Route path="/pokemonInfo" exact>
-              <PokemonInfoTab />
-            </Route>
-            <Route path="/trainers" exact>
-              <Trainers />
-            </Route>
-            <Route path="/moves" exact>
-              <Moves />
-            </Route>
-          </Switch>
+          </Routes>
         </div>
       </Router>
 

--- a/pokedex/src/api/APIUtils.js
+++ b/pokedex/src/api/APIUtils.js
@@ -3,6 +3,11 @@ var urljoin = require('url-join');
 
 const host = "http://localhost:8000";
 
+export const trainerPrefix = "/trainers/";
+export const createResource = "/create/";
+export const updateResource = "/update/";
+export const deleteResource = "/delete/";
+
 // httpEndpoint is the suffix after the host, e.g. the "/var/end/" suffix in "http://google.com/var/end/"
 export const getResource = (httpEndpoint) => 
     fetch(urljoin(host, httpEndpoint), {

--- a/pokedex/src/api/PokedexAPI.js
+++ b/pokedex/src/api/PokedexAPI.js
@@ -1,0 +1,10 @@
+// Network API for accessing move data
+import { getResource, postResource } from "./APIUtils";
+import { trainerPrefix } from "./APIUtils";
+var urljoin = require('url-join');
+
+const pokedex = "/pokedex/"
+const specificTrainer = "/trainer/"
+
+export const findAllPokedexesById = (trainerId) =>
+    getResource(urljoin(trainerPrefix, pokedex, specificTrainer, trainerId.toString()));

--- a/pokedex/src/api/TrainerAPI.js
+++ b/pokedex/src/api/TrainerAPI.js
@@ -1,12 +1,7 @@
 // Network API for accessing move data
 import { getResource, postResource } from "./APIUtils";
+import { trainerPrefix, createResource, updateResource, deleteResource } from "./APIUtils";
 var urljoin = require('url-join');
-
-
-const trainerPrefix = "/trainers/";
-const createResource = "/create/";
-const updateResource = "/update/";
-const deleteResource = "/delete/";
 
 export const findAllTrainers = () =>
     getResource(trainerPrefix);

--- a/pokedex/src/components/Trainers/Pokedex.js
+++ b/pokedex/src/components/Trainers/Pokedex.js
@@ -1,0 +1,50 @@
+// A component used to render a trainer's pokedexes.
+
+import { useEffect, useState } from "react";
+import { Button, ListGroup } from "react-bootstrap";
+import { findAllPokedexesById } from "../../api/PokedexAPI";
+import { findTrainerById } from "../../api/TrainerAPI";
+import Pages from "../Page";
+import {
+    useNavigate,
+    useParams
+  } from "react-router-dom";
+
+export function PokedexList() {
+    const [trainer, setTrainer] = useState({})
+    const [pokedexes, setPokedexes] = useState([])
+
+    let navigate = useNavigate();
+    let { trainerId } = useParams();
+
+    useEffect(() => {
+        if (trainerId !== undefined) {
+            findTrainerById(trainerId)
+                .then(trainer => {setTrainer(trainer); return trainer})
+                .then(trainer => findAllPokedexesById(trainer.pk))
+                .then(pokedexes => setPokedexes(pokedexes))
+        }
+    }, [trainerId])
+
+    return <div>
+        {
+            (Object.keys(trainer).length === 0) ? null : 
+            <>
+            <h1>
+                {trainer.fields.first_name} {trainer.fields.last_name}'s Pokedexes
+            </h1>
+            <Pages itemsInPageLimit={10} items={pokedexes}
+            mapFn={(pokedex, index) => <ListGroup.Item as="li"
+                    className="d-flex justify-content-between align-items-start"
+                    key={index}>
+                    <div className="ms-2 me-auto">
+                        <div className="fw-bold">{pokedex.fields.region}</div>
+                    </div>
+                    <Button className="me-2">Details</Button>
+                </ListGroup.Item>
+            } />
+            </>
+        }
+        <Button className="me-2" onClick={() => navigate(-1)}>Back</Button>
+    </div>
+}

--- a/pokedex/src/components/Trainers/Trainers.js
+++ b/pokedex/src/components/Trainers/Trainers.js
@@ -79,7 +79,7 @@ class PokemonTrainersList extends React.Component {
                     <Badge variant="dark" className="btn-primary me-2 align-self-center" pill>
                         {pokeTrainer.pk}
                     </Badge>
-                    <Button className="me-2" onClick={() => {this.props.navigate(`/trainers/${pokeTrainer.pk}`)
+                    <Button className="me-2" onClick={() => {this.props.navigate(`${pokeTrainer.pk}`)
                     }}>Pokedexes</Button>
                     <Button className="me-2" onClick={() => {
                         this.setState({

--- a/pokedex/src/components/Trainers/Trainers.js
+++ b/pokedex/src/components/Trainers/Trainers.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { createTrainer, findAllTrainers, updateTrainer, deleteTrainer } from '../../api/TrainerAPI';
 import Container from 'react-bootstrap/Container';
 import Col from 'react-bootstrap/Col'
@@ -9,16 +9,26 @@ import Button from 'react-bootstrap/Button';
 import AddTrainersModal from "./AddTrainersModal";
 import EditTrainersModal from "./EditTrainersModal";
 import DelTrainersModal from "./DelTrainersModal";
+import {
+    BrowserRouter as Router,
+    Routes,
+    Route,
+    useNavigate
+  } from "react-router-dom";
 import Pages from '../Page';
+import { PokedexList } from './Pokedex';
 
 export default function Trainers(props) {
-    return <div>
+    let navigate = useNavigate();
+    return (
+    <Routes>
+        <Route path='/' element={
         <Container>
-            <Row>
-                <Col><PokemonTrainersList></PokemonTrainersList></Col>
-            </Row>
-        </Container>
-    </div>
+            <PokemonTrainersList navigate={navigate}/>
+        </Container>}>
+        </Route>
+        <Route path='/:trainerId' element={<PokedexList />} />
+    </Routes>)
 }
 
 class PokemonTrainersList extends React.Component {
@@ -69,6 +79,8 @@ class PokemonTrainersList extends React.Component {
                     <Badge variant="dark" className="btn-primary me-2 align-self-center" pill>
                         {pokeTrainer.pk}
                     </Badge>
+                    <Button className="me-2" onClick={() => {this.props.navigate(`/trainers/${pokeTrainer.pk}`)
+                    }}>Pokedexes</Button>
                     <Button className="me-2" onClick={() => {
                         this.setState({
                             pokemonTrainerIndex: pokeTrainer.pk,


### PR DESCRIPTION
This was painful

Changes
* Adds React Router v6, which makes nesting much easier than v5 did
* Adds initial support for pokedex listing, more to follow on this change to implement one-to-many and many-to-one support
![image](https://user-images.githubusercontent.com/24576987/146105071-11404900-7b43-468b-b145-bc974e3b49de.png)


![image](https://user-images.githubusercontent.com/24576987/146105089-fb966c04-1c72-43a8-aa44-f9622918e015.png)
