### PR TITLE
Pokedex editing support + many to one mapping

### DIFF
--- a/pokedex/src/api/PokedexAPI.js
+++ b/pokedex/src/api/PokedexAPI.js
@@ -1,5 +1,5 @@
 // Network API for accessing move data
-import { getResource, postResource } from "./APIUtils";
+import { createResource, deleteResource, getResource, postResource, updateResource } from "./APIUtils";
 import { trainerPrefix } from "./APIUtils";
 var urljoin = require('url-join');
 
@@ -8,3 +8,12 @@ const specificTrainer = "/trainer/"
 
 export const findAllPokedexesById = (trainerId) =>
     getResource(urljoin(trainerPrefix, pokedex, specificTrainer, trainerId.toString()));
+
+export const createPokedex = (body) => 
+    postResource(urljoin(trainerPrefix, pokedex, createResource) + "/", body);
+
+export const updatePokedexById = (pokedexId, body) =>
+    postResource(urljoin(trainerPrefix, pokedex, updateResource, pokedexId.toString()) + "/", body);
+
+export const deletePokedex = (pokedexId) =>
+    postResource(urljoin(trainerPrefix, pokedex, deleteResource, pokedexId.toString()) + "/", {});

--- a/pokedex/src/components/Trainers/AddPokedexModal.js
+++ b/pokedex/src/components/Trainers/AddPokedexModal.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import { regions } from '../utils/Types';
+const { useState, useEffect } = React;
+
+// Assumes that the pokedex being added is to a specific trainer!
+export default function AddPokedexModal({ show, handleClose, handleSave, trainerId}) {
+    const [region, setRegion] = useState("")
+
+    let payload = {
+        trainer: trainerId,
+        region,
+    }
+
+    return <>
+        <Modal show={show} onHide={handleClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>Add a Pokedex for this trainer!</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form>
+                    <Form.Label>Region</Form.Label>
+                    <Form.Select
+                        value={region}
+                        onChange={(e) => setRegion(e.target.value)}>
+                        <option>Select</option>
+                        {regions.map((region, index) => {
+                            return <option key={index}>{region}</option>
+                        })}
+                    </Form.Select>
+                </Form >
+            </Modal.Body >
+            <Modal.Footer>
+                <Button variant="secondary" onClick={handleClose}>
+                    Close
+                </Button>
+                <Button variant="primary" onClick={() => {handleSave(payload)}}>
+                    Save
+                </Button>
+            </Modal.Footer>
+        </Modal >
+    </>
+}

--- a/pokedex/src/components/Trainers/DelPokedexModal.js
+++ b/pokedex/src/components/Trainers/DelPokedexModal.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+
+export default function DelPokedexModal({ show, handleClose, handleDel, primary_key }) {
+    return <>
+        <Modal show={show} onHide={handleClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>Delete a Pokedex</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                Are you sure you want to delete it? :(
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="secondary" onClick={handleClose}>
+                    Close
+                </Button>
+                <Button variant="danger" onClick={() => handleDel(primary_key)}>
+                    Delete
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    </>
+}

--- a/pokedex/src/components/Trainers/EditPokedexModal.js
+++ b/pokedex/src/components/Trainers/EditPokedexModal.js
@@ -2,8 +2,10 @@ import React from 'react';
 import Modal from 'react-bootstrap/Modal';
 import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
-import { findAllTrainers } from '../../api/TrainerAPI';
+import { findAllTrainers, updateTrainer } from '../../api/TrainerAPI';
 import { regions } from '../utils/Types';
+import { useNavigate } from 'react-router-dom';
+import EditModal from './EditTrainersModal';
 const { useState, useEffect } = React;
 
 export default function EditPokedexModal({ show, handleClose, pokedexes, handleEdit, pokedexIndex }) {
@@ -11,6 +13,7 @@ export default function EditPokedexModal({ show, handleClose, pokedexes, handleE
     const [region, setRegion] = useState("")
     const [trainers, setTrainers] = useState([])
     const [pokedexId, setPokedexId] = useState(0)
+    const [showTrainerModal, setShowTrainerModal] = useState(false)
 
     useEffect(() => {
         if (pokedexes.length !== 0) {
@@ -25,6 +28,11 @@ export default function EditPokedexModal({ show, handleClose, pokedexes, handleE
     useEffect(() => {
         findAllTrainers().then(trainers => setTrainers(trainers))
     }, [pokedexIndex])
+
+    const handleTrainerEdit = async (payload) => {
+        await updateTrainer(payload);
+        window.location.reload();
+    }
 
     let payload = {
         trainer: trainerId,
@@ -66,7 +74,17 @@ export default function EditPokedexModal({ show, handleClose, pokedexes, handleE
                 <Button variant="primary" onClick={() => {handleEdit(pokedexId, payload)}}>
                     Save
                 </Button>
+                <Button variant="primary" onClick={() => {
+                    setShowTrainerModal(true)
+                }}>
+                    Edit Trainer
+                </Button>
             </Modal.Footer>
         </Modal >
+        <EditModal show={showTrainerModal}
+                handleClose={() => setShowTrainerModal(false)}
+                pokemonTrainer={trainers}
+                handleEdit={handleTrainerEdit}
+                pokemonTrainerIndex={(trainers.length === 0) ? -1 : trainers.findIndex((trainer) => trainer.pk === trainerId)} />
     </>
 }

--- a/pokedex/src/components/Trainers/EditPokedexModal.js
+++ b/pokedex/src/components/Trainers/EditPokedexModal.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import { findAllTrainers } from '../../api/TrainerAPI';
+import { regions } from '../utils/Types';
+const { useState, useEffect } = React;
+
+export default function EditPokedexModal({ show, handleClose, pokedexes, handleEdit, pokedexIndex }) {
+    const [trainerId, setTrainerId] = useState(0)
+    const [region, setRegion] = useState("")
+    const [trainers, setTrainers] = useState([])
+    const [pokedexId, setPokedexId] = useState(0)
+
+    useEffect(() => {
+        if (pokedexes.length !== 0) {
+            let pokedex = pokedexes[pokedexIndex];
+            let pokedexFields = pokedex.fields;
+            setPokedexId(pokedex.pk)
+            setTrainerId(pokedexFields.trainer)
+            setRegion(pokedexFields.region)
+        }
+    }, [pokedexIndex])
+
+    useEffect(() => {
+        findAllTrainers().then(trainers => setTrainers(trainers))
+    }, [pokedexIndex])
+
+    let payload = {
+        trainer: trainerId,
+        region,
+    }
+
+    return <>
+        <Modal show={show} onHide={handleClose}>
+            <Modal.Header closeButton>
+                <Modal.Title>Edit a Pokedex!</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form>
+                    <Form.Label>Trainer</Form.Label>
+                    <Form.Select
+                        value={trainerId}
+                        onChange={(e) => setTrainerId(parseInt(e.target.value, 10))}>
+                        <option>Select</option>
+                        {trainers.map((pokeTrainer) => {
+                            return <option key={pokeTrainer.pk}>{pokeTrainer.pk}</option>
+                        })}
+                        </Form.Select>
+                    <br />
+                    <Form.Label>Region</Form.Label>
+                    <Form.Select
+                        value={region}
+                        onChange={(e) => setRegion(e.target.value)}>
+                        <option>Select</option>
+                        {regions.map((region, index) => {
+                            return <option key={index}>{region}</option>
+                        })}
+                    </Form.Select>
+                </Form >
+            </Modal.Body >
+            <Modal.Footer>
+                <Button variant="secondary" onClick={handleClose}>
+                    Close
+                </Button>
+                <Button variant="primary" onClick={() => {handleEdit(pokedexId, payload)}}>
+                    Save
+                </Button>
+            </Modal.Footer>
+        </Modal >
+    </>
+}

--- a/pokedex/src/components/Trainers/EditTrainersModal.js
+++ b/pokedex/src/components/Trainers/EditTrainersModal.js
@@ -68,7 +68,7 @@ export default function EditModal({ show, handleClose, pokemonTrainer, handleEdi
                     <br />
                     <Form.Label>Last Name</Form.Label>
                     <Form.Control
-                        placeholder="Enter First Name"
+                        placeholder="Enter Last Name"
                         value={last_name}
                         onChange={(e) => setLastName(e.target.value)} />
                     <br />

--- a/pokedex/src/components/Trainers/Pokedex.js
+++ b/pokedex/src/components/Trainers/Pokedex.js
@@ -2,20 +2,42 @@
 
 import { useEffect, useState } from "react";
 import { Button, ListGroup } from "react-bootstrap";
-import { findAllPokedexesById } from "../../api/PokedexAPI";
+import { createPokedex, deletePokedex, findAllPokedexesById, updatePokedexById } from "../../api/PokedexAPI";
 import { findTrainerById } from "../../api/TrainerAPI";
 import Pages from "../Page";
 import {
     useNavigate,
     useParams
   } from "react-router-dom";
+import EditPokedexModal from "./EditPokedexModal";
+import AddPokedexModal from "./AddPokedexModal";
+import DelPokedexModal from "./DelPokedexModal";
 
 export function PokedexList() {
     const [trainer, setTrainer] = useState({})
     const [pokedexes, setPokedexes] = useState([])
+    const [pokedexAddModal, setPokedexAddModal] = useState(false)
+    const [pokedexEditModal, setPokedexEditModal] = useState(false)
+    const [pokedexDelModal, setPokedexDelModal] = useState(false)
+    const [pokedexIndex, setPokedexIndex] = useState(-1)
 
     let navigate = useNavigate();
     let { trainerId } = useParams();
+
+    const handleEdit = async (id, payload) => {
+        await updatePokedexById(id, payload)
+        window.location.reload()
+    }
+
+    const handleSave = async (payload) => {
+        await createPokedex(payload)
+        window.location.reload()
+    }
+
+    const handleDel = async (primary_key) => {
+        await deletePokedex(primary_key);
+        window.location.reload()
+    }
 
     useEffect(() => {
         if (trainerId !== undefined) {
@@ -40,11 +62,32 @@ export function PokedexList() {
                     <div className="ms-2 me-auto">
                         <div className="fw-bold">{pokedex.fields.region}</div>
                     </div>
-                    <Button className="me-2">Details</Button>
+                    <Button className="me-2" onClick={() => {
+                        setPokedexIndex(index)
+                        setPokedexEditModal(true)}
+                    }>Edit</Button>
+                    <Button className="me-2" onClick={() => {
+                        setPokedexIndex(index)
+                        setPokedexDelModal(true)}
+                    }>Delete</Button>
                 </ListGroup.Item>
             } />
             </>
         }
+        <AddPokedexModal show={pokedexAddModal}
+                        handleClose={() => {setPokedexAddModal(false)}}
+                        handleSave={handleSave}
+                        trainerId={trainer.pk}/>
+        <EditPokedexModal show={pokedexEditModal} 
+                        handleClose={() => {setPokedexEditModal(false)}} 
+                        pokedexes={pokedexes}
+                        handleEdit={handleEdit}
+                        pokedexIndex={pokedexIndex}/>
+        <DelPokedexModal show={pokedexDelModal}
+                        handleClose={() => {setPokedexDelModal(false)}}
+                        handleDel={handleDel}
+                        primary_key={pokedexes[pokedexIndex]?.pk} />
+        <Button classNamme="me-2" onClick={() => setPokedexAddModal(true)}>Add</Button>
         <Button className="me-2" onClick={() => navigate(-1)}>Back</Button>
     </div>
 }

--- a/pokedex/src/components/Trainers/Trainers.js
+++ b/pokedex/src/components/Trainers/Trainers.js
@@ -17,18 +17,30 @@ import {
   } from "react-router-dom";
 import Pages from '../Page';
 import { PokedexList } from './Pokedex';
+import { useParams } from 'react-router-dom';
 
 export default function Trainers(props) {
-    let navigate = useNavigate();
     return (
     <Routes>
         <Route path='/' element={
         <Container>
-            <PokemonTrainersList navigate={navigate}/>
+            <PokemonTrainersListFunc editModalVisible={false}/>
         </Container>}>
         </Route>
         <Route path='/:trainerId' element={<PokedexList />} />
+        <Route path='/:trainerId/edit' element={<PokemonTrainersListFunc editModalVisible={true} />} />
     </Routes>)
+}
+
+// A make-shift function component to get around React Router's limitations with class components
+function PokemonTrainersListFunc(props) {
+    let navigate = useNavigate();
+    let trainerIndex = 0;
+    let {trainerId} = useParams();
+    if (props.initialEditVisible) {
+        trainerIndex = trainerId;
+    }
+    return <PokemonTrainersList trainerIndex={trainerIndex} editModalVisible={props.editModalVisible} navigate={navigate}/>
 }
 
 class PokemonTrainersList extends React.Component {
@@ -36,9 +48,9 @@ class PokemonTrainersList extends React.Component {
         super(props);
         this.state = {
             pokemonTrainer: [],
-            pokemonTrainerIndex: 0,
+            pokemonTrainerIndex: this.props.trainerIndex,
             addModalVisible: false,
-            editModalVisible: false,
+            editModalVisible: this.props.editModalVisible,
             delModalVisible: false
         }
     }

--- a/pokedex/src/components/Trainers/Trainers.js
+++ b/pokedex/src/components/Trainers/Trainers.js
@@ -28,19 +28,13 @@ export default function Trainers(props) {
         </Container>}>
         </Route>
         <Route path='/:trainerId' element={<PokedexList />} />
-        <Route path='/:trainerId/edit' element={<PokemonTrainersListFunc editModalVisible={true} />} />
     </Routes>)
 }
 
 // A make-shift function component to get around React Router's limitations with class components
 function PokemonTrainersListFunc(props) {
     let navigate = useNavigate();
-    let trainerIndex = 0;
-    let {trainerId} = useParams();
-    if (props.initialEditVisible) {
-        trainerIndex = trainerId;
-    }
-    return <PokemonTrainersList trainerIndex={trainerIndex} editModalVisible={props.editModalVisible} navigate={navigate}/>
+    return <PokemonTrainersList navigate={navigate}/>
 }
 
 class PokemonTrainersList extends React.Component {
@@ -48,9 +42,9 @@ class PokemonTrainersList extends React.Component {
         super(props);
         this.state = {
             pokemonTrainer: [],
-            pokemonTrainerIndex: this.props.trainerIndex,
+            pokemonTrainerId: -1,
             addModalVisible: false,
-            editModalVisible: this.props.editModalVisible,
+            editModalVisible: false,
             delModalVisible: false
         }
     }
@@ -95,13 +89,13 @@ class PokemonTrainersList extends React.Component {
                     }}>Pokedexes</Button>
                     <Button className="me-2" onClick={() => {
                         this.setState({
-                            pokemonTrainerIndex: pokeTrainer.pk,
+                            pokemonTrainerId: pokeTrainer.pk,
                             editModalVisible: true
                         })
                     }}>Edit</Button>
                     <Button variant="danger" onClick={() => {
                         this.setState({
-                            pokemonTrainerIndex: pokeTrainer.pk,
+                            pokemonTrainerId: pokeTrainer.pk,
                             delModalVisible: true
                         })
                     }}>Delete</Button>
@@ -118,12 +112,12 @@ class PokemonTrainersList extends React.Component {
             handleClose={() => this.setState({editModalVisible: false})}
             pokemonTrainer={this.state.pokemonTrainer}
             handleEdit={this.handleEdit}
-            pokemonTrainerIndex={this.findIndex(this.state.pokemonTrainerIndex)} />
+            pokemonTrainerIndex={this.findIndex(this.state.pokemonTrainerId)} />
         <DelTrainersModal
             show={this.state.delModalVisible}
             handleClose={() => this.setState({delModalVisible: false})}
             handleDel={this.handleDel}
-            primary_key={this.state.pokemonTrainer[this.findIndex(this.state.pokemonTrainerIndex)]?.pk} />
+            primary_key={this.state.pokemonTrainer[this.findIndex(this.state.pokemonTrainerId)]?.pk} />
         </div>
     }
 }

--- a/pokedex/src/components/utils/Types.js
+++ b/pokedex/src/components/utils/Types.js
@@ -5,3 +5,4 @@ export const elemEnumType = ["normal", "fire", "water", "electric", "grass", "ic
 
 export const moveEnumType = ["physical", "special", "status"]
 
+export const regions = ["kanto", "johto", "hoenn", "sinnoh", "unova", "kalos", "alola", "galar"]


### PR DESCRIPTION
Big PR! Couple of features I wanted to get out in one batch, apologies for the size

Changes:
* Provides Pokedex editing support, allowing us to edit, delete, add pokedexes
* Re-uses the `EditModal` from Trainers to allow us to implement the P3 requirement that we provide an edit screen linking to the trainer from the many side

![image](https://user-images.githubusercontent.com/24576987/146123926-880b04f5-9425-4b19-b5e3-e49649e17668.png)
![image](https://user-images.githubusercontent.com/24576987/146123948-af8fd017-9f5b-42c1-bb63-ca3c763575c0.png)
![image](https://user-images.githubusercontent.com/24576987/146123969-59017fa0-d900-408e-9dea-72295b027023.png)
![image](https://user-images.githubusercontent.com/24576987/146123990-bfa31663-2f6e-4ea1-86cb-9b91f83a9c7d.png)

After delete:
![image](https://user-images.githubusercontent.com/24576987/146124026-705c0918-018f-4813-9292-d3ba3d162a64.png)

After moving ash's pokedex to gary's pokedexes
![image](https://user-images.githubusercontent.com/24576987/146124071-cf70d9dd-6b11-4e44-a7a9-5477b028ab50.png)

Closes #20 