### PR TITLE
add pokemon type support

### DIFF
--- a/pokedex/src/api/PokemonTypeAPI.js
+++ b/pokedex/src/api/PokemonTypeAPI.js
@@ -23,3 +23,7 @@ export const updatePokemonType = (nationalNum, type) => {
 export const deletePokemonType = (nationalNum, type) => {
     postResource(urljoin(pokemonInfoTypePrefix, "delete/", nationalNum.toString(), type, "/"));
 }
+
+export const applyPokemonType = (nationalNum, types) => {
+    postResource(urljoin(pokemonInfoTypePrefix, "apply/", nationalNum.toString(), "/"), {types: types})
+}

--- a/pokedex/src/components/PokemonInfo/PokemonInfoDetails.js
+++ b/pokedex/src/components/PokemonInfo/PokemonInfoDetails.js
@@ -62,7 +62,7 @@ export default function PokemonInfoDetailsModal({ show, handleClose, pokemonInfo
                     <>
                     <b>Types: </b>
                     <ul>
-                        {pokemonTypes.map((type) => <li>{type}</li>)}
+                        {pokemonTypes.map((type, index) => <li key={index}>{type}</li>)}
                     </ul>
                     </>}
                 Photo: <Image src={photoUrl} fluid />


### PR DESCRIPTION
Adds support for editing a pokemon info's types!

Relies on [backend PR](https://github.com/CookieComputing/db-pokedex-backend/pull/61) for support of the apply function call

![image](https://user-images.githubusercontent.com/24576987/146209732-c2530985-60af-49e4-ae81-1dee24323921.png)
![image](https://user-images.githubusercontent.com/24576987/146209770-d27aa4fa-1ac0-414d-ab43-7b4085b06b3f.png)

Closes #30 