### PR TITLE
add pokedex entry support from pokedex to pokemon info

### DIFF
--- a/pokedex/src/api/PokedexAPI.js
+++ b/pokedex/src/api/PokedexAPI.js
@@ -17,3 +17,6 @@ export const updatePokedexById = (pokedexId, body) =>
 
 export const deletePokedex = (pokedexId) =>
     postResource(urljoin(trainerPrefix, pokedex, deleteResource, pokedexId.toString()) + "/", {});
+
+export const findAllPokemonInfoByPokedexId = (pokedexId) =>
+    getResource(urljoin(trainerPrefix, pokedex, pokedex, pokedexId.toString()))

--- a/pokedex/src/components/Trainers/Pokedex.js
+++ b/pokedex/src/components/Trainers/Pokedex.js
@@ -6,14 +6,27 @@ import { createPokedex, deletePokedex, findAllPokedexesById, updatePokedexById }
 import { findTrainerById } from "../../api/TrainerAPI";
 import Pages from "../Page";
 import {
+    Route,
+    Routes,
     useNavigate,
     useParams
   } from "react-router-dom";
 import EditPokedexModal from "./EditPokedexModal";
 import AddPokedexModal from "./AddPokedexModal";
 import DelPokedexModal from "./DelPokedexModal";
+import { PokedexEntry } from "./PokedexEntry";
 
-export function PokedexList() {
+export default function Pokedex() {
+    return (
+        <Routes>
+            <Route path='/' element={
+                <PokedexList />}>
+            </Route>
+            <Route path='/pokedex/:pokedexId' element={<PokedexEntry />} />
+        </Routes>)
+}
+
+function PokedexList() {
     const [trainer, setTrainer] = useState({})
     const [pokedexes, setPokedexes] = useState([])
     const [pokedexAddModal, setPokedexAddModal] = useState(false)
@@ -62,6 +75,9 @@ export function PokedexList() {
                     <div className="ms-2 me-auto">
                         <div className="fw-bold">{pokedex.fields.region}</div>
                     </div>
+                    <Button className="me-2" onClick={() => {
+                        navigate(`pokedex/${pokedex.pk}`)
+                    }}>Known Pokemon</Button>
                     <Button className="me-2" onClick={() => {
                         setPokedexIndex(index)
                         setPokedexEditModal(true)}

--- a/pokedex/src/components/Trainers/PokedexEntry.js
+++ b/pokedex/src/components/Trainers/PokedexEntry.js
@@ -8,13 +8,14 @@ import {
     useNavigate,
     useParams
   } from "react-router-dom";
-import { updatePokemonInfo } from "../../api/PokemonInfoAPI";
+import { findAllPokemonInfo, updatePokemonInfo } from "../../api/PokemonInfoAPI";
 import EditModal from "../PokemonInfo/EditPokemonInfoModal";
 
 export function PokedexEntry() {
     const [pokemonInfo, setPokemonInfo] = useState([])
     const [pokemonInfoEditModal, setPokemonInfoEditModal] = useState(false)
     const [pokemonInfoIndex, setPokemonInfoIndex] = useState(-1)
+    const [allPokemonInfo, setAllPokemonInfo] = useState([])
 
     let navigate = useNavigate();
     let { pokedexId } = useParams();
@@ -28,6 +29,12 @@ export function PokedexEntry() {
         if (pokedexId !== undefined) {
             findAllPokemonInfoByPokedexId(parseInt(pokedexId, 10))
                 .then(pokemonInfo => {setPokemonInfo(pokemonInfo)})
+        }
+    }, [pokedexId])
+
+    useEffect(() => {
+        if (pokedexId !== undefined) {
+            findAllPokemonInfo().then(pokemonInfo => {setAllPokemonInfo(pokemonInfo)})
         }
     }, [pokedexId])
 
@@ -46,7 +53,7 @@ export function PokedexEntry() {
                         <div className="fw-bold">{pokemonInfo.fields.name}</div>
                     </div>
                     <Button className="me-2" onClick={() => {
-                        setPokemonInfoIndex(index)
+                        setPokemonInfoIndex(allPokemonInfo.findIndex((pokeInfo) => pokeInfo.pk === pokemonInfo.pk))
                         setPokemonInfoEditModal(true)}
                     }>Edit</Button>
                 </ListGroup.Item>
@@ -55,7 +62,7 @@ export function PokedexEntry() {
         }
         <EditModal show={pokemonInfoEditModal}
                         handleClose={() => {setPokemonInfoEditModal(false)}}
-                        pokemonInfo={pokemonInfo}
+                        pokemonInfo={allPokemonInfo}
                         handleEdit={handlePokemonInfoEdit}
                         pokemonInfoIndex={pokemonInfoIndex}/>
         <Button className="me-2" onClick={() => navigate(-1)}>Back</Button>

--- a/pokedex/src/components/Trainers/PokedexEntry.js
+++ b/pokedex/src/components/Trainers/PokedexEntry.js
@@ -1,0 +1,63 @@
+// A component used to render a pokedex's pokemon info
+
+import { useEffect, useState } from "react";
+import { Button, ListGroup } from "react-bootstrap";
+import { findAllPokemonInfoByPokedexId } from "../../api/PokedexAPI";
+import Pages from "../Page";
+import {
+    useNavigate,
+    useParams
+  } from "react-router-dom";
+import { updatePokemonInfo } from "../../api/PokemonInfoAPI";
+import EditModal from "../PokemonInfo/EditPokemonInfoModal";
+
+export function PokedexEntry() {
+    const [pokemonInfo, setPokemonInfo] = useState([])
+    const [pokemonInfoEditModal, setPokemonInfoEditModal] = useState(false)
+    const [pokemonInfoIndex, setPokemonInfoIndex] = useState(-1)
+
+    let navigate = useNavigate();
+    let { pokedexId } = useParams();
+
+    const handlePokemonInfoEdit = async (id, payload) => {
+        await updatePokemonInfo(id, payload)
+        window.location.reload()
+    }
+
+    useEffect(() => {
+        if (pokedexId !== undefined) {
+            findAllPokemonInfoByPokedexId(parseInt(pokedexId, 10))
+                .then(pokemonInfo => {setPokemonInfo(pokemonInfo)})
+        }
+    }, [pokedexId])
+
+    return <div>
+        {
+            (Object.keys(pokemonInfo).length === 0) ? null : 
+            <>
+            <h1>
+                Known Pokemon for Pokedex {pokedexId}
+            </h1>
+            <Pages itemsInPageLimit={10} items={pokemonInfo}
+            mapFn={(pokemonInfo, index) => <ListGroup.Item as="li"
+                    className="d-flex justify-content-between align-items-start"
+                    key={index}>
+                    <div className="ms-2 me-auto">
+                        <div className="fw-bold">{pokemonInfo.fields.name}</div>
+                    </div>
+                    <Button className="me-2" onClick={() => {
+                        setPokemonInfoIndex(index)
+                        setPokemonInfoEditModal(true)}
+                    }>Edit</Button>
+                </ListGroup.Item>
+            } />
+            </>
+        }
+        <EditModal show={pokemonInfoEditModal}
+                        handleClose={() => {setPokemonInfoEditModal(false)}}
+                        pokemonInfo={pokemonInfo}
+                        handleEdit={handlePokemonInfoEdit}
+                        pokemonInfoIndex={pokemonInfoIndex}/>
+        <Button className="me-2" onClick={() => navigate(-1)}>Back</Button>
+    </div>
+}

--- a/pokedex/src/components/Trainers/Trainers.js
+++ b/pokedex/src/components/Trainers/Trainers.js
@@ -16,8 +16,8 @@ import {
     useNavigate
   } from "react-router-dom";
 import Pages from '../Page';
-import { PokedexList } from './Pokedex';
 import { useParams } from 'react-router-dom';
+import Pokedex from './Pokedex';
 
 export default function Trainers(props) {
     return (
@@ -27,7 +27,7 @@ export default function Trainers(props) {
             <PokemonTrainersListFunc editModalVisible={false}/>
         </Container>}>
         </Route>
-        <Route path='/:trainerId' element={<PokedexList />} />
+        <Route path='/:trainerId/*' element={<Pokedex />} />
     </Routes>)
 }
 


### PR DESCRIPTION
Supports viewing all known pokemon info from a pokedex, the inverse will be supported later!

Will add a feature to allow associating and deassociating pokemon info from pokedexes.

![image](https://user-images.githubusercontent.com/24576987/146234124-c114d97b-9c2a-488b-aa77-fd880b7eca25.png)

![image](https://user-images.githubusercontent.com/24576987/146234148-89740e27-1d11-424c-9ce5-cd0c29e4d9c8.png)

![image](https://user-images.githubusercontent.com/24576987/146234178-306625ea-54f8-4c14-86e5-d914807d8673.png)

![image](https://user-images.githubusercontent.com/24576987/146234852-336d04c7-4f6e-44f5-94e1-bd79a31b5f4e.png)
